### PR TITLE
Pull out generic function runner with retry policy

### DIFF
--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -1,0 +1,18 @@
+package functions
+
+import "time"
+
+func RunWithRetryPolicy(backoffSchedule []time.Duration, fn func() error) error {
+	var err error
+
+	for _, backoff := range backoffSchedule {
+		err = fn()
+		if err == nil {
+			break
+		}
+
+		time.Sleep(backoff)
+	}
+
+	return err
+}


### PR DESCRIPTION
Resolves https://github.com/fractalwagmi/fractal-cli/issues/21

Use a basic backoff schedule retry policy to wrap network calls for any transient network failures (or in the case of UpdateBuild, a race between the CLI and an async task to read .zip file manifest).